### PR TITLE
ci: add `licence` file to `paths-ignore`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
             - '**/*.txt'
             - 'CHANGELOG.md'
             - '.github/**'
+            - 'LICENSE'
 
     pull_request:
         branches:
@@ -20,6 +21,7 @@ on:
             - '**/*.txt'
             - 'CHANGELOG.md'
             - '.github/**'
+            - 'LICENSE'
 
 jobs:
     placeholder:


### PR DESCRIPTION
- Added the `LICENCE` file to the `paths-ignore` field in CI workflow