### PR TITLE
fix(build): fix building issue

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { TomTomProvider } from "@/index";
+import { TomTomProvider } from "../src/index.js";
 
 
 describe("index", () => {

--- a/__tests__/providers/tomtom.test.ts
+++ b/__tests__/providers/tomtom.test.ts
@@ -1,4 +1,4 @@
-import { TomTomProvider } from "@/providers/tomtom";
+import { TomTomProvider } from "../../src/providers/tomtom.js";
 
 const TEST_KEY: string = "test-api-key";
 const TEST_BASE_URL: string = "test-base-url";
@@ -118,7 +118,7 @@ describe("TomTom search", () => {
         // Check `fetch` was called with correct endpoint
         expect(fetch).toHaveBeenCalledWith(`https://api.tomtom.com/search/2/search/${TEST_QUERY}.json?key=test-api-key&countrySet=AU`);
         // Check `fetch` returned correct data
-        expect(result).toBe(String({ data: "mock-data" }));
+        expect(result).toBe(JSON.stringify({ data: "mock-data" }));
     });
 
     test("search should throw error", async () => {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -19,7 +19,7 @@ export default [
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        project: "./tsconfig.json"
+        project: "./tsconfig.eslint.json"
       },
       globals: {
         ...globals.node

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,7 +9,7 @@ const config: Config.InitialOptions = {
     "!src/**/*.d.ts"
   ],
   moduleNameMapper: {
-    "^@/(.*)$": "<rootDir>/src/$1" // Maps "@/file" to "src/file"
+    "^(\\.{1,2}/.*)\\.js$": "$1"
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -2,12 +2,15 @@
   "name": "@pandamime100hp/quickroute",
   "version": "1.0.0",
   "description": "A TypeScript library for optimized Australian address parsing and validation, designed specifically for logistics operations. Built with extensibility to support multiple geocoding providers, starting with TomTom API integration.",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix",
     "build": "tsc",
-    "test": "jest --coverage"
+    "test": "jest",
+    "test:coverage": "jest --coverage"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { TomTomProvider } from "@/providers/tomtom";
+export { TomTomProvider } from "./providers/tomtom.js";

--- a/src/providers/tomtom.ts
+++ b/src/providers/tomtom.ts
@@ -1,4 +1,4 @@
-import { ProviderInterface } from "@/provider-interface";
+import { ProviderInterface } from "../provider-interface.js";
 
 // TomTom API docs: https://developer.tomtom.com/search-api/documentation/search-service/fuzzy-search
 
@@ -27,7 +27,7 @@ export class TomTomProvider implements ProviderInterface {
         let endpoint: string = this.generateEndpoint(encodedQuery);
 
         const results: Response = await fetch(endpoint);
-        return String(await results.json());
+        return JSON.stringify(await results.json());
     }
 
     generateEndpoint(query: string): string {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,13 @@
+{
+    "extends": "./tsconfig.json",
+    "include": [
+        "src/**/*.ts", 
+        "__tests__/**/*.ts", 
+        "jest.config.ts", 
+        "eslint.config.ts"
+    ],
+    "exclude": [
+        "node_modules", 
+        "dist"
+    ]
+  }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,7 @@
       "target": "ES2022",
       "lib": ["ES2022"],
       "module": "NodeNext",
-      "moduleResolution": "NodeNext",
-      "types": ["jest"],
+      "types": ["node", "jest"],
   
       /* Strict Type-Checking */
       "strict": true,
@@ -15,11 +14,12 @@
   
       /* Module Resolution */
       "baseUrl": ".",
-      "paths": {
-        "@/*": ["./src/*"]
-      },
-      "rootDir": "./",
+      "rootDir": "./src",
       "outDir": "./dist",
+      "paths": {
+        "*": ["*", "*.js"]
+      },
+      "resolveJsonModule": true,
   
       /* Interop Constraints */
       "esModuleInterop": true,
@@ -36,13 +36,15 @@
     },
     "include": [
       "src/**/*.ts",
-      "__tests__/**/*.ts",
       "eslint.config.ts",
       "jest.config.ts"
     ],
     "exclude": [
       "node_modules",
       "dist",
-      "**/*.spec.ts"
+      "__tests__",
+      "**/*.spec.ts",
+      "jest.config.ts",
+      "eslint.config.ts"
     ]
   }


### PR DESCRIPTION
- Added `tsconfig.eslint.ts` to specify what files to include/exclude during eslint
- Replaced module referencing from `@/...` to relative
- Updated `jest.config.ts` to remove `.js` from import paths to keep tests happy
- Added `paths` to `tsconfig.js` to make sure `src/*` code can reference properly
- Updated `TomTomProvider.search` function to use `JSON.stringify` instead of `String`
- Added `test:coverage` as separate script in `package.json`
- Updated `parserOptions.project` in `eslint.config.ts` to reference `./tsconfig.eslint.json`
- Updated tests to reflect above changes

BREAKING CHANGE: lots of configuration changes