### PR TITLE
feat(address): add `address` type for providers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "1.0.0",
+    "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest: current file",
+    //   "env": { "NODE_ENV": "test" },
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
+      "args": ["${fileBasenameNoExtension}", "--config", "jest.config.ts", "__tests__/"],
+      "console": "integratedTerminal",
+    }
+  ]
+}

--- a/src/provider-interface.ts
+++ b/src/provider-interface.ts
@@ -1,3 +1,0 @@
-export interface ProviderInterface {
-    search(query: string): Promise<string>;
-}

--- a/src/provider_interface.ts
+++ b/src/provider_interface.ts
@@ -1,0 +1,13 @@
+export interface AddressInterface {
+    streetNumber?: string;
+    streetName?: string;
+    municipality?: string;
+    region?: string;
+    postCode?: string;
+    country?: string;
+    freeformAddress?: string;
+}
+
+export interface ProviderInterface {
+    search(query: string): Promise<AddressInterface[]>;
+}


### PR DESCRIPTION
- Added new `AddressInterface` for providers to adhere to
- Added new `TomTomAddress` interface to specify required fields from API call
- Updated `search` function of `TomTomProvider` to use new type
- Renamed `provider-interface` to `provider_interface`
- Update tests to reflect above changes